### PR TITLE
Add external cache write/delete capabilities

### DIFF
--- a/lib/firebolt/cache.rb
+++ b/lib/firebolt/cache.rb
@@ -2,6 +2,13 @@ module Firebolt
   module Cache
     include ::Firebolt::Keys
 
+    def delete(key_suffix, options = nil)
+      salted_key = self.cache_key_with_salt(key_suffix, salt)
+      return nil if salted_key.nil?
+
+      ::Firebolt.config.cache.delete(salted_key, options)
+    end
+
     def fetch(suffix, options = nil, &block)
       salted_key = self.cache_key_with_salt(key_suffix, salt)
       return nil if salted_key.nil?


### PR DESCRIPTION
Allow any external code from Firebolt to write into the cache without
knowing about the salt (in the same way read/fetch work).

Also support delete in the same fashion.

The given key will be salted before the write/delete.
