### PR TITLE
Update rufus-scheduler

### DIFF
--- a/firebolt.gemspec
+++ b/firebolt.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   # Dependencies
   #
   spec.add_dependency "json"
-  spec.add_dependency "rufus-scheduler"
+  spec.add_dependency "rufus-scheduler", "~> 3.0"
   spec.add_dependency "sucker_punch", ">= 1.0"
 
   ##

--- a/lib/firebolt.rb
+++ b/lib/firebolt.rb
@@ -38,9 +38,10 @@ module Firebolt
   def self.initialize_rufus_scheduler
     return if config.warming_frequency.nil?
 
-    warming_frequency = ::Rufus.to_time_string(config.warming_frequency)
+    warming_frequency = config.warming_frequency.to_s
 
-    ::Rufus::Scheduler.start_new.every(warming_frequency) do
+    scheduler = ::Rufus::Scheduler.new
+    scheduler.every(warming_frequency) do
       ::Firebolt::WarmCacheJob.new.async.perform(config.warmer)
     end
   end


### PR DESCRIPTION
Version 3.0 of rufus-scheduler removes the ::Rufus.to_time_string
method. This commit updates the code to be compatible with that change.
I have not done much testing on this yet, other than getting specs to
pass in a project that is dependent on firebolt. It may be more prudent
to just pin the rufus-scheduler depencency to ~> 2.0, either way works
for me.
