### PR TITLE
Spike using concurrent-ruby instead of sucker_punch

### DIFF
--- a/firebolt.gemspec
+++ b/firebolt.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   #
   spec.add_dependency "json"
   spec.add_dependency "rufus-scheduler", "~> 3.0"
-  spec.add_dependency "sucker_punch", ">= 1.0"
+  spec.add_dependency "concurrent-ruby", "~> 1.0.0.pre5"
 
   ##
   # Development Dependencies

--- a/lib/firebolt.rb
+++ b/lib/firebolt.rb
@@ -1,6 +1,6 @@
 require "json"
 require "securerandom"
-require "sucker_punch"
+require "concurrent"
 require "rufus/scheduler"
 
 require "firebolt/keys"
@@ -58,7 +58,9 @@ module Firebolt
 
     # Initial warming
     warmer = config.use_file_warmer? ? ::Firebolt::FileWarmer : config.warmer
-    ::Firebolt::WarmCacheJob.new.async.perform(config.warmer)
+    # Should the argument be `warmer` and not `config.warmer`?
+    #::Firebolt::WarmCacheJob.new.async.perform(config.warmer)
+    Concurrent::Future.execute { ::Firebolt::WarmCacheJob.new.perform(config.warmer) }
 
     initialized!
   end

--- a/lib/firebolt/warm_cache_job.rb
+++ b/lib/firebolt/warm_cache_job.rb
@@ -1,6 +1,5 @@
 module Firebolt
   class WarmCacheJob
-    include ::SuckerPunch::Job
 
     def perform(warmer_class)
       cache_warmer = warmer_class.new


### PR DESCRIPTION
I saw an issued raised by @film42 on the Sucker Punch repo and thought I might be able to help. Looking at the source in your gem, Sucker Punch (and by extension Celluloid) may not be the best tool for your use case. I think [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby) may be a better fit. (FYI: I'm the creator and lead maintainer of c-r.)

Concurrent Ruby is the concurrency library being used in the next version of [Rails](https://github.com/rails/rails/blob/master/activesupport/activesupport.gemspec#L27), the next version of [Sidekiq](https://github.com/mperham/sidekiq/blob/master/sidekiq.gemspec#L22), possibly [Sucker Punch](https://github.com/brandonhilkert/sucker_punch/blob/concurrent/sucker_punch.gemspec#L25), and several other projects.

In this PR I've replaced Sucker Punch/Celluloid with a simple `Future`. This is a *much* leaner abstraction that will run the job asynchronously in the background. It uses a high-performance thread pool which should perform must faster with far less memory overhead. Additionally, concurrent-ruby detects the runtime (MRI, JRuby, Rbx) and makes several runtime-specific optimizations. On JRuby the performance improvement should be even better.

If this works for you please don't hesitate to reach out to me. I'm happy to help in any way I can.