### PR TITLE
Update concurrent ruby and fix WarmCacheJob initialization

### DIFF
--- a/firebolt.gemspec
+++ b/firebolt.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   #
   spec.add_dependency "json"
   spec.add_dependency "rufus-scheduler", "~> 3.0"
-  spec.add_dependency "concurrent-ruby", "~> 1.0.0.pre5"
+  spec.add_dependency "concurrent-ruby", "~> 1.0"
 
   ##
   # Development Dependencies

--- a/lib/firebolt.rb
+++ b/lib/firebolt.rb
@@ -58,9 +58,7 @@ module Firebolt
 
     # Initial warming
     warmer = config.use_file_warmer? ? ::Firebolt::FileWarmer : config.warmer
-    # Should the argument be `warmer` and not `config.warmer`?
-    #::Firebolt::WarmCacheJob.new.async.perform(config.warmer)
-    Concurrent::Future.execute { ::Firebolt::WarmCacheJob.new.perform(config.warmer) }
+    ::Concurrent::Future.execute { ::Firebolt::WarmCacheJob.new.perform(warmer) }
 
     initialized!
   end


### PR DESCRIPTION
Looks like we have a typo where we never let anyone use a FileWarmer even if the specify it in the config. There are no tests for this gem #nailedit so I'm not sure if it will break thing or not.

Anyways, looking to get this fixed up. Here we go!

cc @liveh2o @abrandoned @mmmries @quixoten @localshred 