### PR TITLE
Remove file wamer auto-enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To use Firebolt, you first need to configure it.
   config.warmer = ::YourAwesomeCacheWarmer
 
   # Optional
-  config.cache_file_enabled = true # Automatically enabled when cache_file_path is set
+  config.cache_file_enabled = true
   config.cache_file_path = '/path/to/your/project/tmp' # Defaults to /tmp
 end
 ```

--- a/lib/firebolt/config.rb
+++ b/lib/firebolt/config.rb
@@ -60,7 +60,6 @@ module Firebolt
     def cache_file_path=(path)
       raise ArgumentError, "Directory '#{path}' does not exist or is not writable." unless ::File.writable?(path)
 
-      self[:cache_file_enabled] = true
       self[:cache_file_path] = path
     end
 


### PR DESCRIPTION
Firebolt's railtie auto-enables file warming, because it will set the
file warming path.  This is often not desired because other things might
want to configure the warmer.

This removes the auto-enable of the file warmer and now it must be
explicity enabled to use it.